### PR TITLE
Added Minesweeper Audience

### DIFF
--- a/lib/game_platform/game_server/game_spec.ex
+++ b/lib/game_platform/game_server/game_spec.ex
@@ -1,0 +1,22 @@
+defmodule GamePlatform.GameServer.GameSpec do
+  defstruct [
+    :game_module,
+    :init_player,
+    :game_config,
+  ]
+
+  @type t :: %__MODULE__{
+    game_module: module(),
+    init_player: String.t(),
+    game_config: any(),
+  }
+
+  @spec make(module(), String.t(), any()) :: t()
+  def make(module, init_player, config) do
+    %__MODULE__{
+      game_module: module,
+      init_player: init_player,
+      game_config: config,
+    }
+  end
+end

--- a/lib/game_platform/game_state.ex
+++ b/lib/game_platform/game_state.ex
@@ -18,7 +18,7 @@ defmodule GamePlatform.GameState do
 
   Called by the game server during initialization. (In a :continue)
   """
-  @callback init(game_config :: term()) :: {:ok, game_state()} | {:error, term()}
+  @callback init(game_config :: term(), init_player :: player_id()) :: {:ok, game_state()} | {:error, term()}
 
   @doc """
   Tells the state that the provided player is attempting to join the game.

--- a/lib/game_platform/game_supervisor.ex
+++ b/lib/game_platform/game_supervisor.ex
@@ -5,6 +5,7 @@ defmodule GamePlatform.GameSupervisor do
 
   use DynamicSupervisor
 
+  alias GamePlatform.GameServer.GameSpec
   alias GamePlatform.GameRegistry
   alias GamePlatform.GameServer
 
@@ -15,7 +16,7 @@ defmodule GamePlatform.GameSupervisor do
   @doc """
   Start a new game server with the given specs and ID length.
   """
-  @spec start_game(GameServer.game_spec_t(), map(), integer()) ::
+  @spec start_game(GameSpec.t(), map(), integer()) ::
     {:ok, String.t(), any()}
     | {:error, :ignore | :max_children | :unknown}
   def start_game(game_spec, server_config, id_length \\ 4)

--- a/lib/web_games.ex
+++ b/lib/web_games.ex
@@ -7,23 +7,26 @@ defmodule WebGames do
   if it comes from the database, an external API or others.
   """
 
+  alias GamePlatform.GameServer.GameSpec
   alias WebGames.Minesweeper.GameState, as: MinesweeperState
   alias WebGames.LightCycles.GameState, as: LightCyclesState
 
-  def start_minesweeper(_player_id, minesweeper_config) do
-    # TODO: Include player id in config
+  def start_minesweeper(player_id, minesweeper_config) do
     server_config = %{
       pubsub: WebGames.PubSub,
+      player_disconnect_timeout_length: :timer.seconds(15),
     }
 
-    GamePlatform.GameSupervisor.start_game({MinesweeperState, minesweeper_config}, server_config)
+    GameSpec.make(MinesweeperState, player_id, minesweeper_config)
+    |> GamePlatform.GameSupervisor.start_game(server_config)
   end
 
-  def start_lightcycles(_player_id, lightcycles_config) do
+  def start_lightcycles(player_id, lightcycles_config) do
     server_config = %{
       pubsub: WebGames.PubSub,
     }
-    GamePlatform.GameSupervisor.start_game({LightCyclesState, lightcycles_config}, server_config)
+    GameSpec.make(LightCyclesState, player_id, lightcycles_config)
+    |> GamePlatform.GameSupervisor.start_game(server_config)
   end
 
   # TODO: Wrap this in a ":dev" check

--- a/lib/web_games/light_cycles/game_state.ex
+++ b/lib/web_games/light_cycles/game_state.ex
@@ -67,7 +67,7 @@ defmodule WebGames.LightCycles.GameState do
   }
 
   @impl true
-  def init(config) do
+  def init(config, _init_player) do
     state = %__MODULE__{
       free_spaces: MapSet.new(generate_blank_grid(config.width, config.height)),
       height: config.height,

--- a/lib/web_games/minesweeper/game_state.ex
+++ b/lib/web_games/minesweeper/game_state.ex
@@ -223,6 +223,11 @@ defmodule WebGames.Minesweeper.GameState do
     {:ok, [PubSubMessage.build(:all, {:shutdown, :normal}, :shutdown)], game}
   end
 
+  def handle_event(%__MODULE__{player: active_player_id} = game, player_id, _) when player_id != active_player_id do
+    # Only accept events from the active player.
+    {:ok, [], game}
+  end
+
   @impl true
   def handle_event(%__MODULE__{} = game, _, :restart) do
     unless game.end_game_ref |> is_nil() do

--- a/lib/web_games_web/controllers/new_game_controller.ex
+++ b/lib/web_games_web/controllers/new_game_controller.ex
@@ -8,7 +8,6 @@ defmodule WebGamesWeb.NewGameController do
   def start_minesweeper(conn, %{"width" => width, "height" => height, "num_mines" => num_mines, "type" => "custom"}) do
     player_id = get_player_id(conn)
 
-    # TODO: Handle config validation
     minesweeper_config = Minesweeper.Config.custom(width, height, num_mines)
 
     if Minesweeper.Config.valid?(minesweeper_config) do

--- a/lib/web_games_web/live/minesweeper/player_component.html.heex
+++ b/lib/web_games_web/live/minesweeper/player_component.html.heex
@@ -1,5 +1,6 @@
 <div class="text-white">
   <div class="max-w-xl mx-auto my-3">
+    <div>Viewing: <%= @audience_size %></div>
     <div :if={!is_nil(@start_time)}><p phx-hook="MinesweeperTimer" id="timer" phx-value-start_time={@start_time} phx-update="ignore" class="font-mono text-2xl text-center">00:00</p></div>
     <div :if={is_nil(@start_time)}><p class="font-mono text-2xl text-center">00:00</p></div>
     <div class="grid grid-cols-3 h-10">
@@ -7,7 +8,9 @@
       <span class="font-bold text-center">
         <span :if={@status in [:win, :lose]}>
           <%= @display_status %>
-          <.button phx-click="restart" phx-target={@myself} class="mx-2">Play again?</.button>
+          <span :if={@player_type == :player}>
+            <.button phx-click="restart" phx-target={@myself} class="mx-2">Play again?</.button>
+          </span>
         </span>
       </span>
       <span class="text-right"><span class="font-bold">Game: </span><%= @game_type %></span>
@@ -18,9 +21,9 @@
       <%= for {{x,y}, cell} <- @display_grid do %>
         <div style={"grid-column-start:#{x};grid-row-start:#{y}"} id={"cell_box_#{x}_#{y}"}>
           <div class={"w-8 h-8 #{cell.background_color} #{cell.text_color} #{cell.border_color} border text-center"}
-            phx-click={if @clicks_enabled?, do: "click", else: nil}
+            phx-click={if @clicks_enabled? && @player_type == :player, do: "click", else: nil}
             phx-target={@myself}
-            phx-hook="MinesweeperFlag"
+            phx-hook={if @player_type == :player, do: "MinesweeperFlag", else: nil}
             phx-value-x={x}
             phx-value-y={y}
             id={"cell_click_#{x}_#{y}"}

--- a/test/game_platform/game_server/init_test.exs
+++ b/test/game_platform/game_server/init_test.exs
@@ -1,10 +1,12 @@
 defmodule GamePlatform.GameServer.InitTest do
   use GamePlatform.GameServerCase
 
+  alias GamePlatform.GameServer.GameSpec
+
   test "start_link fails if :pubsub is not set" do
     init_args = {
       "ABCD",
-      {MockGameState, %{conf: :success}},
+      GameSpec.make(MockGameState, "playerid_1", %{conf: :success}),
       %{},
     }
     assert {:error, :invalid_config} === GameServer.start_link(init_args)
@@ -13,7 +15,7 @@ defmodule GamePlatform.GameServer.InitTest do
   test "start_link fails if :game_timeout_length is negative" do
     init_args = {
       "ABCD",
-      {MockGameState, %{conf: :success}},
+      GameSpec.make(MockGameState, "playerid_1", %{conf: :success}),
       %{
         pubsub: WebGames.PubSub,
         game_timeout_length: -50,
@@ -25,7 +27,7 @@ defmodule GamePlatform.GameServer.InitTest do
   test "start_link fails if :player_disconnect_timeout_length is negative" do
     init_args = {
       "ABCD",
-      {MockGameState, %{conf: :success}},
+      GameSpec.make(MockGameState, "playerid_1", %{conf: :success}),
       %{
         pubsub: WebGames.PubSub,
         player_disconnect_timeout_length: -50,
@@ -37,7 +39,7 @@ defmodule GamePlatform.GameServer.InitTest do
   test "init initializes server state, then continues to game state" do
     init_args = {
       "ABCD",
-      {MockGameState, %{conf: :success}},
+      GameSpec.make(MockGameState, "playerid_1", %{conf: :success}),
       %{},
     }
 
@@ -65,7 +67,7 @@ defmodule GamePlatform.GameServer.InitTest do
     {:noreply, new_state} = GameServer.handle_continue(:init_game, state)
 
     # State module is called
-    assert_called MockGameState.init(%{conf: :success})
+    assert_called MockGameState.init(%{conf: :success}, "playerid_1")
     # Game state is initialized
     assert new_state.game_state === %{state: :initialized}
     # Game timeout is scheduled
@@ -81,6 +83,6 @@ defmodule GamePlatform.GameServer.InitTest do
     # Need to figure out a better way to handle this in the future maybe.
     # If for no better reason than for communication to the frontend.
     assert_raise MatchError, fn -> GameServer.handle_continue(:init_game, state) end
-    assert_called MockGameState.init(%{conf: :failed})
+    assert_called MockGameState.init(%{conf: :failed}, "playerid_1")
   end
 end

--- a/test/support/game_server_case.ex
+++ b/test/support/game_server_case.ex
@@ -38,6 +38,7 @@ defmodule GamePlatform.GameServerCase do
       game_config: %{conf: :success},
       game_state: %{game_type: :test},
       start_time: ~U[2024-01-06 23:25:38.371659Z],
+      init_player: "playerid_1",
       server_config: %{
         game_timeout_length: :timer.minutes(5),
         player_disconnect_timeout_length: :timer.minutes(2),

--- a/test/support/mock_game_state.ex
+++ b/test/support/mock_game_state.ex
@@ -3,11 +3,11 @@ defmodule GamePlatform.MockGameState do
     view_module: GamePlatform.MockGameView,
     display_name: "MOCK_GAME"
 
-  def init(%{conf: :failed}) do
+  def init(%{conf: :failed}, _player_id) do
     {:error, :invalid_config}
   end
 
-  def init(_game_config) do
+  def init(_game_config, _player_id) do
     {:ok, %{state: :initialized}}
   end
 

--- a/test/web_games/minesweeper/game_state_test.exs
+++ b/test/web_games/minesweeper/game_state_test.exs
@@ -270,7 +270,7 @@ defmodule WebGames.Minesweeper.GameStateTest do
     ]
   end
 
-  test "restart event resets game state, sends sync notification", %{state: state} do
+  test "restart event resets game state, sends sync notifications", %{state: state} do
     state = state
     |> Map.put(:player, "playerid_1")
 
@@ -351,6 +351,14 @@ defmodule WebGames.Minesweeper.GameStateTest do
         audience_size: 0,
       }}}
     ]
+  end
+
+  test "game events are blocked for non-active players", %{state: state} do
+    state = state
+    |> Map.put(:player, "playerid_1")
+
+    {:ok, [], new_state} = GameState.handle_event(state, "playerid_2", {:open, {1,1}})
+    assert new_state === state
   end
 
   test "restart event resets game shutdown timer if it exists", %{state: state} do


### PR DESCRIPTION
Finished forwarding initial player ID to game server

This let me add the "player" to Minesweeper immediately, meaning I can now distinguish between the player who created the game and anyone else. So now Minesweeper has an "audience" mode.